### PR TITLE
Trim output for comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,16 @@ runs:
           DIFFUSE_OUTPUT="${DIFFUSE_OUTPUT//$'\n'/'%0A'}"
           DIFFUSE_OUTPUT="${DIFFUSE_OUTPUT//$'\r'/'%0D'}"
           echo "::set-output name=diff_details::$DIFFUSE_OUTPUT"
+      
+      - name: Get workflow run job url
+        id: get_run_job_url
+        run: |-
+          workflowRunJobUrl=$(curl \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          "${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+          | jq -M -r '.jobs[] | select(.name == "${{ github.job }}").html_url')
+          echo "::set-output name=workflow_run_job_url::$workflowRunJobUrl"      
 
       - name: Find Comment
         uses: peter-evans/find-comment@v2
@@ -71,4 +81,5 @@ runs:
             ```
             ${{ steps.diff_apk.outputs.diff_details }} 
             ```
+            More detailed logs can be found here --> ${{ steps.get_run_job_url.outputs.workflow_run_job_url }}
           edit-mode: replace

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
         run: |-
           workflowRunJobUrl=$(curl \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Authorization: Bearer ${{ inputs.github_token }}" \
           "${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
           | jq -M -r '.jobs[] | select(.name == "${{ github.job }}").html_url')
           echo "::set-output name=workflow_run_job_url::$workflowRunJobUrl"      

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,7 @@ runs:
           echo "::set-output name=diff_details::$DIFFUSE_OUTPUT"
       
       - name: Get workflow run job url
+        shell: bash
         id: get_run_job_url
         run: |-
           workflowRunJobUrl=$(curl \

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         run: |-
           brew install JakeWharton/repo/diffuse
           diffuse diff downloads/apk/${{ steps.old_apk_sha.outputs.old_apk_sha }}/*.apk ${{ inputs.new_apk }}
-          DIFFUSE_OUTPUT=$(diffuse diff downloads/apk/${{ steps.old_apk_sha.outputs.old_apk_sha }}/*.apk ${{ inputs.new_apk }})
+          DIFFUSE_OUTPUT=$(diffuse diff downloads/apk/${{ steps.old_apk_sha.outputs.old_apk_sha }}/*.apk ${{ inputs.new_apk }} | head -70)
           DIFFUSE_OUTPUT="${DIFFUSE_OUTPUT//'%'/'%25'}"
           DIFFUSE_OUTPUT="${DIFFUSE_OUTPUT//$'\n'/'%0A'}"
           DIFFUSE_OUTPUT="${DIFFUSE_OUTPUT//$'\r'/'%0D'}"


### PR DESCRIPTION
## What
• Trims diffuse output to first 70 lines, this is commented on the PR. The full output is still present in the build logs. First 70 lines were chosen so it does contain the most important information for various changes. 
• Get the workflow run job url using the [Rest Api](https://docs.github.com/en/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run) and append that in the comment for easy access to detailed logs.
